### PR TITLE
Should use relative path for images

### DIFF
--- a/reference_guides/ofminer/guide/How To Create an OFMiner Report.md
+++ b/reference_guides/ofminer/guide/How To Create an OFMiner Report.md
@@ -44,7 +44,7 @@ mkdir CUSTOMER.JCLLIB
 
 Please refer to the below picture on where you can find the SYNC button.
 
-![alt-text](https://github.com/tmaxsoft-us/Rehosting_Guide_A-Z/blob/master/reference/ofminer/reference_images/Edit-OFMiner%20SYNC.png "SYNC")
+![alt-text](./../reference_images/Edit-OFMiner%20SYNC.png "SYNC")
 
 5. **Analyze the JCL**
 
@@ -58,7 +58,7 @@ Please refer to the below picture on where you can find the SYNC button.
 
 After you analyze, you can go to the missing resources section on the left hand side of the screen. Under this section, you will find missing procedures and you will use this list for step 6. 
 
-![alt-text](https://github.com/tmaxsoft-us/Rehosting_Guide_A-Z/blob/master/reference/ofminer/reference_images/Edit-OFMiner%20JCL%20Analyze.jpg "Analyze JCL") 
+![alt-text](./../reference_images/Edit-OFMiner%20JCL%20Analyze.jpg "Analyze JCL") 
 
 6. **Create a PDS (or multiple) for the in-scope PROCs**
 

--- a/reference_guides/source_transfer/guide/How To Transfer Source Code from the Mainframe.md
+++ b/reference_guides/source_transfer/guide/How To Transfer Source Code from the Mainframe.md
@@ -68,14 +68,14 @@ You can download WinSCP for free here: https://winscp.net/eng/download.php
 
 When you open WinSCP, it will ask you for a New Site. Please reference the image below:
 
-![alt text](https://github.com/tmaxsoft-us/Rehosting_Guide_A-Z/blob/master/reference_guides/source_transfer/reference_pictures/new_site.png "New Site")
+![alt text](./../reference_pictures/new_site.png "New Site")
 
 Once you have created a New Site, fill in the information for connecting to the server. Please reference the image below:
 
-![alt text](https://github.com/tmaxsoft-us/Rehosting_Guide_A-Z/blob/master/reference_guides/source_transfer/reference_pictures/new_session.png "New Session")
+![alt text](./../reference_pictures/new_session.png "New Session")
 
 Lastly, once you have connected, simply click and drag the source directories from one machine to the other. Please reference the image below:
 
-![alt text](https://github.com/tmaxsoft-us/Rehosting_Guide_A-Z/blob/master/reference_guides/source_transfer/reference_pictures/WinSCP%20Transfer.png "Transfer")
+![alt text](./../reference_pictures/WinSCP%20Transfer.png "Transfer")
 
 


### PR DESCRIPTION
Instead of giving full URL path,
it is recommended to use relative path since the image might not show properly.